### PR TITLE
Set minSdk from 21 to 18

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 18
     }
     lintOptions {
         disable 'InvalidPackage'
@@ -40,5 +40,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.googlecode.libphonenumber:libphonenumber:8.12.5"
+    implementation "com.googlecode.libphonenumber:libphonenumber:8.12.10"
 }


### PR DESCRIPTION
Hi,
I downgrade the Android minSdk from 21 to 18, otherwise this package cannot be used for some projects that use a low sdk version (like mine).
I also updated com.googlecode.libphonenumber lib.