### PR TITLE
Implement flutter web plugin.

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,49 +5,56 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: a937da4c006989739ceb4d10e3bd6cce64ca85d0fe287fc5b2b9f6ee757dcee6
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.3"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -67,32 +74,49 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.5"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   sky_engine:
@@ -104,51 +128,58 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=1.10.0"

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -1,6 +1,21 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <!--
+    If you are serving your web app in a path other than the root, change the
+    href value below to reflect the base path you are serving from.
+
+    The path provided below has to start and end with a slash "/" in order for
+    it to work correctly.
+
+    For more details:
+    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+
+    This is a placeholder for base href that will be replaced by the value of
+    the `--base-href` argument provided to `flutter build`.
+  -->
+  <base href="$FLUTTER_BASE_HREF">
+
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Demonstrates how to use the flutter_libphonenumber plugin.">
@@ -8,26 +23,37 @@
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="flutter_libphonenumber_example">
+  <meta name="apple-mobile-web-app-title" content="goooooo">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
-  <link rel="shortcut icon" type="image/png" href="favicon.png"/>
+  <link rel="icon" type="image/png" href="favicon.png"/>
 
   <title>flutter_libphonenumber_example</title>
   <link rel="manifest" href="manifest.json">
+
+  <script>
+    // The value below is injected by flutter build, do not touch.
+    var serviceWorkerVersion = null;
+  </script>
+  <!-- This script adds the flutter initialization JS code -->
+  <script src="flutter.js" defer></script>
 </head>
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', function () {
-        navigator.serviceWorker.register('flutter_service_worker.js');
+    window.addEventListener('load', function(ev) {
+      // Download main.dart.js
+      _flutter.loader.loadEntrypoint({
+        serviceWorker: {
+          serviceWorkerVersion: serviceWorkerVersion,
+        },
+        onEntrypointLoaded: function(engineInitializer) {
+          engineInitializer.initializeEngine().then(function(appRunner) {
+            appRunner.runApp();
+          });
+        }
       });
-    }
+    });
   </script>
-  <script src="main.dart.js" type="application/javascript"></script>
 </body>
 </html>

--- a/lib/flutter_libphonenumber_web.dart
+++ b/lib/flutter_libphonenumber_web.dart
@@ -1,0 +1,121 @@
+import 'dart:ui';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_libphonenumber/src/web/base.dart';
+import 'package:flutter_libphonenumber/src/web/libphonenumber.dart';
+import 'package:flutter_libphonenumber/src/web/utils.dart';
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+import 'dart:html' as html;
+
+const String libPhoneNumberVersion = '3.2.32';
+const String libPhoneNumberUrl =
+    'https://cdn.jsdelivr.net/npm/google-libphonenumber@$libPhoneNumberVersion/dist/libphonenumber.min.js';
+
+class FlutterLibphonenumberWebPlugin {
+  static late Future _jsLibrariesLoadingFuture;
+  static void registerWith(Registrar registrar) {
+    final MethodChannel channel = MethodChannel('flutter_libphonenumber', const StandardMethodCodec(), registrar);
+    channel.setMethodCallHandler(FlutterLibphonenumberWebPlugin.handleMethodCall);
+    setupScripts();
+  }
+
+  static void setupScripts() {
+    final libraries = [JsLibrary(contextName: 'libphonenumber', url: libPhoneNumberUrl, usesRequireJs: true)];
+    final helperScriptTag = html.ScriptElement()
+      ..type = 'application/javascript'
+      ..text = '''
+      function libPhoneNumberFlutterGetRegionDisplayNames(lang) {
+          return new Intl.DisplayNames([lang], {type: 'region'});
+      }
+    ''';
+
+    html.document.head!.append(helperScriptTag);
+    _jsLibrariesLoadingFuture = injectJSLibraries(libraries);
+  }
+
+  static Future<dynamic> handleMethodCall(MethodCall call) async {
+    await _jsLibrariesLoadingFuture;
+    switch (call.method) {
+      case 'get_all_supported_regions':
+        return getAllSupportedRegions();
+      case 'parse':
+        return parse(call);
+      case 'format':
+        return format(call);
+      default:
+        throw PlatformException(
+          code: 'Unimplemented',
+          details: "The flutter_libphonenumber plugin for web doesn't implement the method ${call.method}",
+        );
+    }
+  }
+
+  static Future<Map<String, Map<String, String>>> getAllSupportedRegions() async {
+    final util = PhoneNumberUtil.getInstance();
+    final res = <String, Map<String, String>>{};
+    final displayNames = libPhoneNumberFlutterGetRegionDisplayNames(window.locale.languageCode);
+    for (final region in util.getSupportedRegions()) {
+      final exampleNumberMobile = util.getExampleNumberForType(region, PhoneNumberType.MOBILE) ?? PhoneNumber();
+      final exampleNumberFixedLine = util.getExampleNumberForType(region, PhoneNumberType.FIXED_LINE) ?? PhoneNumber();
+      final phoneCode = util.getCountryCodeForRegion(region).toString();
+      final item = {
+        'phoneCode': phoneCode,
+        'exampleNumberMobileNational': formatNational(exampleNumberMobile).toString(),
+        'exampleNumberFixedLineNational': formatNational(exampleNumberFixedLine).toString(),
+        'phoneMaskMobileNational': maskNumber(formatNational(exampleNumberMobile).toString(), phoneCode),
+        'phoneMaskFixedLineNational': maskNumber(formatNational(exampleNumberFixedLine).toString(), phoneCode),
+        'exampleNumberMobileInternational': formatInternational(exampleNumberMobile).toString(),
+        'exampleNumberFixedLineInternational': formatInternational(exampleNumberFixedLine).toString(),
+        'phoneMaskMobileInternational': maskNumber(formatInternational(exampleNumberMobile).toString(), phoneCode),
+        'phoneMaskFixedLineInternational':
+            maskNumber(formatInternational(exampleNumberFixedLine).toString(), phoneCode),
+        'countryName': displayNames.of(region),
+      };
+      res[region] = item;
+    }
+    return res;
+  }
+
+  static Future<Map<String, String>> parse(MethodCall methodCall) async {
+    final region = methodCall.arguments['region'] as String?;
+    final phone = methodCall.arguments['phone'] as String?;
+    if (phone == null) {
+      throw PlatformException(code: 'InvalidParameters', message: "Invalid 'phone' parameter.");
+    }
+    final util = PhoneNumberUtil.getInstance();
+    final res = util.parseStringAndRegion(phone, region);
+    if (res != null) {
+      return res;
+    } else {
+      throw PlatformException(code: 'InvalidNumber', message: 'Number $phone is invalid');
+    }
+  }
+
+  static Future<Map<String, String>> format(MethodCall methodCall) async {
+    final region = methodCall.arguments['region'] as String?;
+    final phone = methodCall.arguments['phone'] as String?;
+    if (phone == null) {
+      throw PlatformException(code: 'InvalidParameters', message: "Invalid 'phone' parameter.");
+    }
+    try {
+      final formatter = AsYouTypeFormatter(region);
+      formatter.clear();
+      String formatted = '';
+      for (final char in phone.split('')) {
+        formatted = formatter.inputDigit(char);
+      }
+      return {'formatted': formatted};
+    } catch (_) {
+      throw PlatformException(code: 'InvalidNumber', message: 'Number $phone is invalid');
+    }
+  }
+
+  static String maskNumber(String phoneNumber, String phoneCode) => phoneNumber.replaceAll(RegExp(r'\d'), '0');
+
+  static String formatNational(PhoneNumber phoneNumber) =>
+      PhoneNumberUtil.getInstance().format(phoneNumber, PhoneNumberFormat.NATIONAL);
+
+  static String formatInternational(PhoneNumber phoneNumber) =>
+      PhoneNumberUtil.getInstance().format(phoneNumber, PhoneNumberFormat.INTERNATIONAL);
+}

--- a/lib/src/web/base.dart
+++ b/lib/src/web/base.dart
@@ -1,6 +1,42 @@
+// BSD 3-Clause License
+
+// Copyright (c) 2022, Julian Steenbakker
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import 'package:js/js.dart';
 
 class JsLibrary {
+  const JsLibrary({
+    required this.contextName,
+    required this.url,
+    required this.usesRequireJs,
+  });
+
   /// The name of global variable where library is stored.
   /// Used to properly import the library if [usesRequireJs] flag is true
   final String contextName;
@@ -10,12 +46,6 @@ class JsLibrary {
   /// E.g. if at the beginning you see code like
   /// if (typeof define === "function" && define.amd)
   final bool usesRequireJs;
-
-  const JsLibrary({
-    required this.contextName,
-    required this.url,
-    required this.usesRequireJs,
-  });
 }
 
 @JS('Promise')

--- a/lib/src/web/base.dart
+++ b/lib/src/web/base.dart
@@ -1,0 +1,34 @@
+import 'package:js/js.dart';
+
+class JsLibrary {
+  /// The name of global variable where library is stored.
+  /// Used to properly import the library if [usesRequireJs] flag is true
+  final String contextName;
+  final String url;
+
+  /// If js code checks for 'define' variable.
+  /// E.g. if at the beginning you see code like
+  /// if (typeof define === "function" && define.amd)
+  final bool usesRequireJs;
+
+  const JsLibrary({
+    required this.contextName,
+    required this.url,
+    required this.usesRequireJs,
+  });
+}
+
+@JS('Promise')
+@staticInterop
+class Promise<T> {}
+
+@JS('Map')
+@staticInterop
+class JsMap {
+  external factory JsMap();
+}
+
+extension JsMapExt on JsMap {
+  external void set(dynamic key, dynamic value);
+  external dynamic get(dynamic key);
+}

--- a/lib/src/web/libphonenumber.dart
+++ b/lib/src/web/libphonenumber.dart
@@ -1,0 +1,119 @@
+// ignore_for_file: non_constant_identifier_names
+@JS()
+library libphonenumber;
+
+import 'package:js/js.dart';
+
+@JS()
+external DisplayNames libPhoneNumberFlutterGetRegionDisplayNames(String lang);
+
+@JS('Intl.DisplayNames')
+class DisplayNames {
+  external String of(String countryCode);
+}
+
+@JS('libphonenumber.PhoneNumber')
+class PhoneNumber {
+  external PhoneNumber();
+  external String getCountryCode();
+  external String getNationalNumber();
+}
+
+@JS('libphonenumber.PhoneNumberFormat')
+class PhoneNumberFormat {
+  external static int E164;
+  external static int INTERNATIONAL;
+  external static int NATIONAL;
+  external static int RFC3966;
+}
+
+@JS('libphonenumber.PhoneNumberType')
+class PhoneNumberType {
+  external static int FIXED_LINE;
+  external static int MOBILE;
+  external static int FIXED_LINE_OR_MOBILE;
+  external static int TOLL_FREE;
+  external static int PREMIUM_RATE;
+  external static int SHARED_COST;
+  external static int VOIP;
+  external static int PERSONAL_NUMBER;
+  external static int PAGER;
+  external static int UAN;
+  external static int VOICEMAIL;
+  external static int UNKNOWN;
+}
+
+String numberTypeToString(int type) {
+  switch (type) {
+    case 0:
+      return 'fixedLine';
+    case 1:
+      return 'mobile';
+    case 2:
+      return 'fixedOrMobile';
+    case 3:
+      return 'tollFree';
+    case 4:
+      return 'premiumRate';
+    case 5:
+      return 'sharedCost';
+    case 6:
+      return 'voip';
+    case 7:
+      return 'personalNumber';
+    case 8:
+      return 'pager';
+    case 9:
+      return 'uan';
+    case 10:
+      return 'voiceMail';
+    case -1:
+      return 'unknown';
+    default:
+      return 'notParsed';
+  }
+}
+
+@JS('libphonenumber.AsYouTypeFormatter')
+class AsYouTypeFormatter {
+  external AsYouTypeFormatter(String? regionCode);
+  external void clear();
+  external String inputDigit(String char);
+}
+
+@JS('libphonenumber.PhoneNumberUtil')
+class PhoneNumberUtil {
+  external static PhoneNumberUtil getInstance();
+  external Map<String, dynamic> getExampleNumber(String regionCode);
+  external PhoneNumber parse(String phoneNumber, String? regionCode);
+  external bool isValidNumber(PhoneNumber phoneNumber);
+  external int getNumberType(PhoneNumber phoneNumber);
+  external String format(PhoneNumber phoneNumber, int phoneNumberFormat);
+  external String getRegionCodeForNumber(PhoneNumber phoneNumber);
+  external List<String> getSupportedRegions();
+  external int getCountryCodeForRegion(String? region);
+  external PhoneNumber? getExampleNumberForType(String region, int type);
+}
+
+extension PhoneNumberUtilExt on PhoneNumberUtil {
+  Map<String, String>? parseStringAndRegion(String phone, String? region) {
+    try {
+      final phoneNumber = parse(phone, region);
+      if (!isValidNumber(phoneNumber)) {
+        return null;
+      } else {
+        return {
+          'type': numberTypeToString(getNumberType(phoneNumber)),
+          'e164': format(phoneNumber, PhoneNumberFormat.E164),
+          'international': format(phoneNumber, PhoneNumberFormat.INTERNATIONAL),
+          'national': format(phoneNumber, PhoneNumberFormat.NATIONAL),
+          'country_code': phoneNumber.getCountryCode(),
+          'region_code': getRegionCodeForNumber(phoneNumber),
+          'national_number': phoneNumber.getNationalNumber(),
+        };
+      }
+    } catch (e) {
+      return null;
+    }
+  }
+}

--- a/lib/src/web/utils.dart
+++ b/lib/src/web/utils.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+import 'dart:html' as html;
+import 'dart:js' show context, JsObject;
+
+import 'base.dart';
+
+Future<void> loadScript(JsLibrary library) async {
+  dynamic amd;
+  dynamic define;
+  // ignore: avoid_dynamic_calls
+  if (library.usesRequireJs && context['define']?['amd'] != null) {
+    // In dev, requireJs is loaded in. Disable it here.
+    // see https://github.com/dart-lang/sdk/issues/33979
+    define = JsObject.fromBrowserObject(context['define'] as Object);
+    // ignore: avoid_dynamic_calls
+    amd = define['amd'];
+    // ignore: avoid_dynamic_calls
+    define['amd'] = false;
+  }
+  try {
+    await loadScriptUsingScriptTag(library.url);
+  } finally {
+    if (amd != null) {
+      // Re-enable requireJs
+      // ignore: avoid_dynamic_calls
+      define['amd'] = amd;
+    }
+  }
+}
+
+Future<void> loadScriptUsingScriptTag(String url) {
+  final script = html.ScriptElement()
+    ..async = true
+    ..defer = false
+    ..crossOrigin = 'anonymous'
+    ..type = 'text/javascript'
+    // ignore: unsafe_html
+    ..src = url;
+
+  html.document.head!.append(script);
+
+  return script.onLoad.first;
+}
+
+/// Injects JS [libraries]
+///
+/// Returns a [Future] that resolves when all of the `script` tags `onLoad` events trigger.
+Future<void> injectJSLibraries(List<JsLibrary> libraries) {
+  final List<Future<void>> loading = [];
+
+  for (final library in libraries) {
+    final future = loadScript(library);
+    loading.add(future);
+  }
+
+  return Future.wait(loading);
+}

--- a/lib/src/web/utils.dart
+++ b/lib/src/web/utils.dart
@@ -1,3 +1,33 @@
+// BSD 3-Clause License
+
+// Copyright (c) 2022, Julian Steenbakker
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import 'dart:async';
 import 'dart:html' as html;
 import 'dart:js' show context, JsObject;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,91 +5,104 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: d93b0378aadce9c1388108067946276582c2ae89426c64c17920c74988508fed
+      url: "https://pub.dev"
     source: hosted
     version: "22.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "581a0281129283e75d4d67d6ac6e391c0515cdce37eb6eb4bc8a52e65d2b16b6"
+      url: "https://pub.dev"
     source: hosted
     version: "1.7.2"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "3d82ff8620ec576fd38f6cec0df45a7c088b8704eb1c63d4c336392e5efca6ca"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
-      url: "https://pub.dartlang.org"
+      sha256: cd9cfe046f8b4d87f45abce8f14ec315a4eaedcf92a211e83fa080faf9ec7c1c
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.3"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: f08428ad63615f96a27e34221c65e1a451439b5f26030f78d790f461c686d65d
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: cf75650c66c0316274e21d7c43d3dea246273af5955bd94e8184837cd577575c
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: b69516f2c26a5bcac4eee2e32512e1a5205ab312b3536c1c1227b2b942b5f9ad
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
   flutter:
@@ -102,74 +115,97 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: dda85ce2aefce16f7e75586acbcb1e8320bf176f69fd94082e31945d6de67f3e
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  js:
+    dependency: "direct main"
+    description:
+      name: js
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.5"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "20e7154d701fedaeb219dad732815ecb66677667871127998a9a6581c2aba4ba"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
-      url: "https://pub.dartlang.org"
+      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
   pigeon:
     dependency: "direct dev"
     description:
       name: pigeon
-      url: "https://pub.dartlang.org"
+      sha256: "3464d6fe56447125e8cc7c38d840828321bfeffcf4438d7efd3fe4a25ed376c9"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "59ed538734419e81f7fc18c98249ae72c3c7188bdd9dceff2840585227f79843"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   sky_engine:
@@ -181,72 +217,82 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "68173f2fa67d241323a4123be7ed4e43424c54befa5505d71c8ad4b7baf8f71d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "3cee79b1715110341012d27756d9bae38e650588acd38d3f3c610822e1337ace"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=1.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  js: ^0.6.5
+  flutter_web_plugins:
+    sdk: flutter
 
 dev_dependencies:
   flutter_test:
@@ -33,6 +36,9 @@ flutter:
         pluginClass: FlutterLibphonenumberPlugin
       ios:
         pluginClass: FlutterLibphonenumberPlugin
+      web:
+        pluginClass: FlutterLibphonenumberWebPlugin
+        fileName: flutter_libphonenumber_web.dart
   # To add assets to your plugin package, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
Web implementation for libphonenumber. 

Uses google-libphonenumber from jsdelivr https://www.jsdelivr.com/package/npm/google-libphonenumber 

No setup needed, script tags are injected at plugin initialization time (using code from [mobile scanner plugin](https://github.com/juliansteenbakker/mobile_scanner/)).

The code is a straightforward porting of the Kotlin plugin code.
I'm not very well versed in JS interop, and I couldn't find a way to correctly build the `Intl.DisplayNames` object used to fill in the country name in `getAllSupportedRegions()`. 
I tried declaring a constructor for `DisplayNames` on the dart side but it would fail with a weird error 
```
missing "type" option in DisplayNames()
```
even though I was passing it. I tried with both a simple `Map` or a `JsObject` as parameter, with no luck.

Having failed at that, I resorted to declaring a factory function `libPhoneNumberFlutterGetRegionDisplayNames()` in javascript.

I'm using this in our company's app - it works fine, but for some reason there seems to be a problem with loading the library on the example app, so I marked it as draft.

Please note the code taken from mobile scanner is BSD-3 licensed. I included the copyright notice in the relevant files.
